### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/templates/agenttrack.json
+++ b/templates/agenttrack.json
@@ -224,7 +224,7 @@
 			]
 		  },
 		  "Timeout": 10,
-		  "Runtime": "nodejs8.10"
+		  "Runtime": "nodejs10.x"
 		}
 	  },
 	  "SmgNextQuestionLambda": {
@@ -252,14 +252,14 @@
 			]
 		  },
 		  "Timeout": 10,
-		  "Runtime": "nodejs8.10"
+		  "Runtime": "nodejs10.x"
 		}
 	  },
 	  "SmgStackTestLambda": {
 		"Type": "AWS::Lambda::Function",
 		"Properties": {
 		  "Handler": "index.quickstart",
-		  "Runtime": "nodejs8.10",
+		  "Runtime": "nodejs10.x",
 		  "Description": "SMG AgentTrack integration test",
 		  "Environment": {
 			"Variables": {


### PR DESCRIPTION
CloudFormation templates in connect-integration-smg-agenttrack have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.